### PR TITLE
Fix for (breaking?) change in `syn`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["rust-patterns"]
 quote = "1.0"
 syn = "1.0"
 heck = "0.3"
+proc-macro2 = "1.0"
 
 [dev-dependencies]
 variant_count = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,15 +90,16 @@ Use `FieldName` and/or `FieldType` in `derive` struct attribute.
 !*/
 
 extern crate proc_macro;
+extern crate proc_macro2;
 extern crate syn;
 extern crate quote;
 extern crate heck;
 
 use std::iter::FromIterator;
 use proc_macro::TokenStream;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use syn::{
     DeriveInput, Ident, Type, Attribute, Fields, Meta, Path, PathArguments, PathSegment,
-    export::{Span, TokenStream2},
     punctuated::Punctuated,
 };
 use quote::{quote, ToTokens};


### PR DESCRIPTION
`syn::export` no longer exists, which I have to assume was a breaking change from them.

I've pulled in `proc-macro2` directly to get those imports which were previously acquired indirectly via `syn`.